### PR TITLE
Source object for rendering templates

### DIFF
--- a/lib/deas-erubis/source.rb
+++ b/lib/deas-erubis/source.rb
@@ -1,0 +1,42 @@
+require 'pathname'
+require 'erubis'
+
+module Deas; end
+module Deas::Erubis
+
+  class Source
+
+    EXT = ".erb"
+
+    attr_reader :root, :eruby_class, :context_class
+
+    def initialize(root, locals = nil)
+      @root = Pathname.new(root.to_s)
+      @eruby_class = ::Erubis::Eruby # TODO: allow for custom classes
+      @context_class = Class.new do
+        (locals || {}).each{ |key, value| define_method(key){ value } }
+        # TODO: mixin context helpers?
+      end
+    end
+
+    def inspect
+      "#<#{self.class}:#{'0x0%x' % (object_id << 1)} @root=#{@root.inspect}>"
+    end
+
+    private
+
+    def source_file_path(file_name)
+      self.root.join("#{file_name}#{EXT}").to_s
+    end
+
+  end
+
+  class DefaultSource < Source
+
+    def initialize
+      super('/')
+    end
+
+  end
+
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,12 +1,16 @@
 # this file is automatically required when you run `assert`
 # put any test helpers here
 
+require 'pathname'
+
 # add the root dir to the load path
-$LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
+ROOT = Pathname.new(File.expand_path("../..", __FILE__))
+$LOAD_PATH.unshift(ROOT.to_s)
+
+TEST_SUPPORT_PATH = ROOT.join('test/support')
+TEMPLATE_ROOT = TEST_SUPPORT_PATH.join('templates')
 
 # require pry for debugging (`binding.pry`)
 require 'pry'
 
 require 'test/support/factory'
-
-# TODO: put test helpers here...

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -3,4 +3,20 @@ require 'assert/factory'
 module Factory
   extend Assert::Factory
 
+  def self.template_root
+    TEMPLATE_ROOT.to_s
+  end
+
+  def self.template_file(name)
+    TEMPLATE_ROOT.join(name).to_s
+  end
+
+  def self.template_erb_rendered(view_handler, locals)
+    "<h1>name: #{view_handler.name}</h1>\n"\
+    "<h2>local1: #{locals['local1']}</h2>\n"
+  end
+
+  def self.partial_erb_rendered(locals)
+    "<h2>local1: #{locals['local1']}</h2>\n"
+  end
 end

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -1,0 +1,71 @@
+require 'assert'
+require 'deas-erubis/source'
+
+require 'erubis'
+
+class Deas::Erubis::Source
+
+  class UnitTests < Assert::Context
+    desc "Deas::Erubis::Source"
+    setup do
+      @source_class = Deas::Erubis::Source
+    end
+    subject{ @source_class }
+
+    should "know its extension" do
+      assert_equal ".erb", subject::EXT
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @root = Factory.template_root
+      @source = @source_class.new(@root)
+    end
+    subject{ @source }
+
+    should have_readers :root, :eruby_class, :context_class
+
+    should "know its root" do
+      assert_equal @root, subject.root.to_s
+    end
+
+    should "know its eruby class" do
+      assert_equal ::Erubis::Eruby, subject.eruby_class
+    end
+
+    should "know its context class" do
+      assert_instance_of ::Class, subject.context_class
+    end
+
+    should "optionally take and apply default locals to its context class" do
+      local_name, local_val = [Factory.string, Factory.string]
+      source = @source_class.new(@root, local_name => local_val)
+      context = source.context_class.new
+
+      assert_responds_to local_name, context
+      assert_equal local_val, context.send(local_name)
+    end
+
+  end
+
+  class DefaultSource < UnitTests
+    desc "DefaultSource"
+    setup do
+      @source = Deas::Erubis::DefaultSource.new
+    end
+    subject{ @source }
+
+    should "be a Source" do
+      assert_kind_of @source_class, subject
+    end
+
+    should "use `/` as its root" do
+      assert_equal '/', subject.root.to_s
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds a source object for specifying and rendering template
files.  Create a source object for the given root of source files
you want to render.  It knows the root dir of the files it can
render plus the eruby/context class to render them with.

This is setup for implementing Deas' rendering API.
