### PR TITLE
basic template engine with rendering api not implemented

### DIFF
--- a/lib/deas-erubis.rb
+++ b/lib/deas-erubis.rb
@@ -1,5 +1,52 @@
+require 'deas/template_engine'
+require 'erubis'
+
 require "deas-erubis/version"
+require "deas-erubis/source"
 
 module Deas::Erubis
-  # TODO: your code goes here...
+
+  class TemplateEngine < Deas::TemplateEngine
+
+    DEFAULT_HANDLER_LOCAL = 'view'.freeze
+    DEFAULT_LOGGER_LOCAL  = 'logger'.freeze
+
+    def erb_source
+      @erb_source ||= Source.new(self.source_path, {
+        self.erb_logger_local => self.logger
+      })
+    end
+
+    def erb_handler_local
+      @erb_handler_local ||= (self.opts['handler_local'] || DEFAULT_HANDLER_LOCAL)
+    end
+
+    def erb_logger_local
+      @erb_logger_local ||= (self.opts['logger_local'] || DEFAULT_LOGGER_LOCAL)
+    end
+
+    def render(template_name, view_handler, locals)
+      # TODO: render passing view handler as local
+      # TODO: look at view handler layouts and render in them??
+      raise NotImplementedError
+    end
+
+    def partial(template_name, locals)
+      # TODO: render template with given context locals
+      raise NotImplementedError
+    end
+
+    def capture_partial(template_name, locals, &content)
+      # TODO: render template with given locals yielding to given content
+      raise NotImplementedError
+    end
+
+    private
+
+    def render_locals(view_handler, locals)
+      { self.erb_handler_local => view_handler }.merge(locals)
+    end
+
+  end
+
 end

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -1,0 +1,71 @@
+require 'assert'
+require 'deas-erubis'
+
+require 'deas/template_engine'
+require 'deas-erubis/source'
+
+class Deas::Erubis::TemplateEngine
+
+  class UnitTests < Assert::Context
+    desc "Deas::Erubis::TemplateEngine"
+    setup do
+      @engine = Deas::Erubis::TemplateEngine.new({
+        'source_path' => TEST_SUPPORT_PATH
+      })
+    end
+    subject{ @engine }
+
+    should have_imeths :erb_source, :erb_handler_local, :erb_logger_local
+    should have_imeths :render, :partial, :capture_partial
+
+    should "be a Deas template engine" do
+      assert_kind_of Deas::TemplateEngine, subject
+    end
+
+    should "memoize its erb source" do
+      assert_kind_of Deas::Erubis::Source, subject.erb_source
+      assert_equal subject.source_path, subject.erb_source.root
+      assert_same subject.erb_source, subject.erb_source
+    end
+
+    should "use 'view' as the handler local name by default" do
+      assert_equal 'view', subject.erb_handler_local
+    end
+
+    should "allow custom handler local names" do
+      handler_local = Factory.string
+      engine = Deas::Erubis::TemplateEngine.new('handler_local' => handler_local)
+      assert_equal handler_local, engine.erb_handler_local
+    end
+
+    should "use 'logger' as the logger local name by default" do
+      assert_equal 'logger', subject.erb_logger_local
+    end
+
+    should "allow custom logger local names" do
+      logger_local = Factory.string
+      engine = Deas::Erubis::TemplateEngine.new('logger_local' => logger_local)
+      assert_equal logger_local, engine.erb_logger_local
+    end
+
+    should "not implement the engine render method" do
+      assert_raises NotImplementedError do
+        subject.render('template.erb', 'a-view-handler', {})
+      end
+    end
+
+    should "not implement the engine partial method" do
+      assert_raises NotImplementedError do
+        subject.partial('_partial.erb', {})
+      end
+    end
+
+    should "not implement the engine capture partial method" do
+      assert_raises NotImplementedError do
+        subject.capture_partial('_partial.erb', {})
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
This gets the basic template engine in place with the rendering
api not implemented for now.  This is setup for implementing the
render api at the source and hooking it up to Deas via the template
engine.

This covers the basics: setting the default logger/view locals,
creating the source object with the logger and setting up the render
API.

@jcredding ready for review.
