### PR TITLE
add engine option for specifying a custom eruby

### DIFF
--- a/lib/deas-erubis.rb
+++ b/lib/deas-erubis.rb
@@ -12,7 +12,7 @@ module Deas::Erubis
     DEFAULT_LOGGER_LOCAL  = 'logger'.freeze
 
     def erb_source
-      @erb_source ||= Source.new(self.source_path, {
+      @erb_source ||= Source.new(self.source_path, self.opts['eruby'], {
         self.erb_logger_local => self.logger
       })
     end

--- a/lib/deas-erubis/source.rb
+++ b/lib/deas-erubis/source.rb
@@ -7,20 +7,26 @@ module Deas::Erubis
   class Source
 
     EXT = ".erb"
+    DEFAULT_ERUBY = ::Erubis::Eruby
 
     attr_reader :root, :eruby_class, :context_class
 
-    def initialize(root, locals = nil)
+    def initialize(root, *args)
       @root = Pathname.new(root.to_s)
-      @eruby_class = ::Erubis::Eruby # TODO: allow for custom classes
+      locals, @eruby_class = [
+        args.last.kind_of?(::Hash) ? args.pop : {},
+        args.last || DEFAULT_ERUBY
+      ]
       @context_class = Class.new do
-        (locals || {}).each{ |key, value| define_method(key){ value } }
         # TODO: mixin context helpers?
+        locals.each{ |key, value| define_method(key){ value } }
       end
     end
 
     def inspect
-      "#<#{self.class}:#{'0x0%x' % (object_id << 1)} @root=#{@root.inspect}>"
+      "#<#{self.class}:#{'0x0%x' % (object_id << 1)}"\
+      " @root=#{@root.inspect}"\
+      " @eruby=#{@eruby_class.inspect}>"
     end
 
     private

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -16,6 +16,10 @@ class Deas::Erubis::Source
       assert_equal ".erb", subject::EXT
     end
 
+    should "know its default eruby class" do
+      assert_equal ::Erubis::Eruby, subject::DEFAULT_ERUBY
+    end
+
   end
 
   class InitTests < UnitTests
@@ -32,12 +36,18 @@ class Deas::Erubis::Source
       assert_equal @root, subject.root.to_s
     end
 
-    should "know its eruby class" do
-      assert_equal ::Erubis::Eruby, subject.eruby_class
+    should "default its eruby class" do
+      assert_equal Deas::Erubis::Source::DEFAULT_ERUBY, subject.eruby_class
     end
 
     should "know its context class" do
       assert_instance_of ::Class, subject.context_class
+    end
+
+    should "optionally take a custom eruby class" do
+      eruby = 'some-eruby-class'
+      source = @source_class.new(@root, eruby)
+      assert_equal eruby, source.eruby_class
     end
 
     should "optionally take and apply default locals to its context class" do

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -28,6 +28,12 @@ class Deas::Erubis::TemplateEngine
       assert_same subject.erb_source, subject.erb_source
     end
 
+    should "allow custom eruby classes on its source" do
+      custom_eruby = 'some-eruby'
+      engine = Deas::Erubis::TemplateEngine.new('eruby' => custom_eruby)
+      assert_equal custom_eruby, engine.erb_source.eruby_class
+    end
+
     should "use 'view' as the handler local name by default" do
       assert_equal 'view', subject.erb_handler_local
     end


### PR DESCRIPTION
By default, `::Erubis::Eruby` will be used to render the templates.
However, erubis supports many alternate erubys and even erubys with
custom enhancers.  This allows you to build/specify a custom eruby
and use it in the engine.

@jcredding ready for review.
