### PR TITLE
basic render implementation

### DIFF
--- a/lib/deas-erubis.rb
+++ b/lib/deas-erubis.rb
@@ -26,9 +26,8 @@ module Deas::Erubis
     end
 
     def render(template_name, view_handler, locals)
-      # TODO: render passing view handler as local
       # TODO: look at view handler layouts and render in them??
-      raise NotImplementedError
+      self.erb_source.render(template_name, render_locals(view_handler, locals))
     end
 
     def partial(template_name, locals)

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -11,12 +11,16 @@ module Factory
     TEMPLATE_ROOT.join(name).to_s
   end
 
-  def self.template_erb_rendered(view_handler, locals)
-    "<h1>name: #{view_handler.name}</h1>\n"\
+  def self.basic_erb_rendered(locals)
+    "<h1>name: #{locals['name']}</h1>\n"\
     "<h2>local1: #{locals['local1']}</h2>\n"
   end
 
-  def self.partial_erb_rendered(locals)
-    "<h2>local1: #{locals['local1']}</h2>\n"
+  def self.view_erb_rendered(engine, view_handler, locals)
+    "<h1>name: #{view_handler.name}</h1>\n"\
+    "<h2>local1: #{locals['local1']}</h2>\n"\
+    "<p>id: #{view_handler.identifier}</p>\n"\
+    "<p>logger: #{engine.logger.to_s}</p>\n"
   end
+
 end

--- a/test/support/templates/basic.erb
+++ b/test/support/templates/basic.erb
@@ -1,0 +1,2 @@
+<h1>name: <%= name %></h1>
+<h2>local1: <%= local1 %></h2>

--- a/test/support/templates/basic.erb.cache
+++ b/test/support/templates/basic.erb.cache
@@ -1,0 +1,4 @@
+_buf = ''; _buf << '<h1>name: '; _buf << ( name ).to_s; _buf << '</h1>
+<h2>local1: '; _buf << ( local1 ).to_s; _buf << '</h2>
+';
+_buf.to_s

--- a/test/support/templates/view.erb
+++ b/test/support/templates/view.erb
@@ -1,0 +1,4 @@
+<h1>name: <%= view.name %></h1>
+<h2>local1: <%= local1 %></h2>
+<p>id: <%= view.identifier %></p>
+<p>logger: <%= logger %></p>

--- a/test/support/templates/view.erb.cache
+++ b/test/support/templates/view.erb.cache
@@ -1,0 +1,6 @@
+_buf = ''; _buf << '<h1>name: '; _buf << ( view.name ).to_s; _buf << '</h1>
+<h2>local1: '; _buf << ( local1 ).to_s; _buf << '</h2>
+<p>id: '; _buf << ( view.identifier ).to_s; _buf << '</p>
+<p>logger: '; _buf << ( logger ).to_s; _buf << '</p>
+';
+_buf.to_s

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -31,6 +31,7 @@ class Deas::Erubis::Source
     subject{ @source }
 
     should have_readers :root, :eruby_class, :context_class
+    should have_imeths :render
 
     should "know its root" do
       assert_equal @root, subject.root.to_s
@@ -53,10 +54,36 @@ class Deas::Erubis::Source
     should "optionally take and apply default locals to its context class" do
       local_name, local_val = [Factory.string, Factory.string]
       source = @source_class.new(@root, local_name => local_val)
-      context = source.context_class.new
+      context = source.context_class.new({})
 
       assert_responds_to local_name, context
       assert_equal local_val, context.send(local_name)
+    end
+
+    should "apply locals to its context class instances on init" do
+      local_name, local_val = [Factory.string, Factory.string]
+      context = subject.context_class.new(local_name => local_val)
+
+      assert_responds_to local_name, context
+      assert_equal local_val, context.send(local_name)
+    end
+
+  end
+
+  class RenderTests < InitTests
+    desc "`render` method"
+    setup do
+      @file_name = "basic"
+      @file_locals = {
+        'name'   => Factory.string,
+        'local1' => Factory.integer
+      }
+      @file_path = Factory.template_file("#{@file_name}#{Deas::Erubis::Source::EXT}")
+    end
+
+    should "render a template for the given file name and return its data" do
+      exp = Factory.basic_erb_rendered(@file_locals)
+      assert_equal exp, subject.render(@file_name, @file_locals)
     end
 
   end

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -54,10 +54,18 @@ class Deas::Erubis::TemplateEngine
       assert_equal logger_local, engine.erb_logger_local
     end
 
-    should "not implement the engine render method" do
-      assert_raises NotImplementedError do
-        subject.render('template.erb', 'a-view-handler', {})
-      end
+    should "render erb templates" do
+      engine = Deas::Erubis::TemplateEngine.new({
+        'source_path' => TEMPLATE_ROOT
+      })
+      view_handler = OpenStruct.new({
+        :identifier => Factory.integer,
+        :name => Factory.string
+      })
+      locals = { 'local1' => Factory.string }
+      exp = Factory.view_erb_rendered(engine, view_handler, locals).to_s
+
+      assert_equal exp, engine.render('view', view_handler, locals)
     end
 
     should "not implement the engine partial method" do


### PR DESCRIPTION
This updates the source to add in basic rendering logic.  The source
builds a context class with any given locals, then loads to given
template file and evaluates it against the context.

This also updates the engine to define the render method and call
to the source to perform the render.  The implements the `render`
portion of the deas engine API.

@jcredding ready for review
