### PR TITLE
custom cache root engine option

### DIFF
--- a/lib/deas-erubis.rb
+++ b/lib/deas-erubis.rb
@@ -12,8 +12,10 @@ module Deas::Erubis
     DEFAULT_LOGGER_LOCAL  = 'logger'.freeze
 
     def erb_source
-      @erb_source ||= Source.new(self.source_path, self.opts['eruby'], {
-        self.erb_logger_local => self.logger
+      @erb_source ||= Source.new(self.source_path, {
+        :cache_root     => self.opts['cache_root'],
+        :eruby          => self.opts['eruby'],
+        :default_locals => { self.erb_logger_local => self.logger }
       })
     end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,6 +9,7 @@ $LOAD_PATH.unshift(ROOT.to_s)
 
 TEST_SUPPORT_PATH = ROOT.join('test/support')
 TEMPLATE_ROOT = TEST_SUPPORT_PATH.join('templates')
+TEMPLATE_CACHE_ROOT = ROOT.join('tmp/templates')
 
 # require pry for debugging (`binding.pry`)
 require 'pry'

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -28,6 +28,12 @@ class Deas::Erubis::TemplateEngine
       assert_same subject.erb_source, subject.erb_source
     end
 
+    should "allow custom cache roots on its source" do
+      custom_cache = Factory.path
+      engine = Deas::Erubis::TemplateEngine.new('cache_root' => custom_cache)
+      assert_equal custom_cache, engine.erb_source.cache_root
+    end
+
     should "allow custom eruby classes on its source" do
       custom_eruby = 'some-eruby'
       engine = Deas::Erubis::TemplateEngine.new('eruby' => custom_eruby)


### PR DESCRIPTION
This adds support for specifying a custom cache root.  By default
the engine caches template files alongside the source files (the
cache root is the same as the source root).  Specify custom cache
root to store cache templates in another root dir.

Note, I had to add the step of creating the cache files dir if it
didn't exists.  Erubis doesn't do this automatically :(.  Not sure
if there will be a performance impact on this but will look out for
it.

@jcredding ready for review.
