### PR TITLE
More options for template caching

### DIFF
--- a/lib/deas-erubis.rb
+++ b/lib/deas-erubis.rb
@@ -13,8 +13,8 @@ module Deas::Erubis
 
     def erb_source
       @erb_source ||= Source.new(self.source_path, {
-        :cache_root     => self.opts['cache_root'],
         :eruby          => self.opts['eruby'],
+        :cache          => self.opts['cache'],
         :default_locals => { self.erb_logger_local => self.logger }
       })
     end

--- a/test/support/templates/basic.erb.cache
+++ b/test/support/templates/basic.erb.cache
@@ -1,4 +1,0 @@
-_buf = ''; _buf << '<h1>name: '; _buf << ( name ).to_s; _buf << '</h1>
-<h2>local1: '; _buf << ( local1 ).to_s; _buf << '</h2>
-';
-_buf.to_s

--- a/test/support/templates/view.erb.cache
+++ b/test/support/templates/view.erb.cache
@@ -1,6 +1,0 @@
-_buf = ''; _buf << '<h1>name: '; _buf << ( view.name ).to_s; _buf << '</h1>
-<h2>local1: '; _buf << ( local1 ).to_s; _buf << '</h2>
-<p>id: '; _buf << ( view.identifier ).to_s; _buf << '</p>
-<p>logger: '; _buf << ( logger ).to_s; _buf << '</p>
-';
-_buf.to_s

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -28,16 +28,15 @@ class Deas::Erubis::TemplateEngine
       assert_same subject.erb_source, subject.erb_source
     end
 
-    should "allow custom cache roots on its source" do
-      custom_cache = Factory.path
-      engine = Deas::Erubis::TemplateEngine.new('cache_root' => custom_cache)
-      assert_equal custom_cache, engine.erb_source.cache_root
-    end
-
     should "allow custom eruby classes on its source" do
       custom_eruby = 'some-eruby'
       engine = Deas::Erubis::TemplateEngine.new('eruby' => custom_eruby)
       assert_equal custom_eruby, engine.erb_source.eruby_class
+    end
+
+    should "allow custom cache roots on its source" do
+      engine = Deas::Erubis::TemplateEngine.new('cache' => TEMPLATE_CACHE_ROOT)
+      assert_equal TEMPLATE_CACHE_ROOT.to_s, engine.erb_source.cache_root.to_s
     end
 
     should "use 'view' as the handler local name by default" do


### PR DESCRIPTION
This updates the source to provide more caching options.  The goal
here is to provide options to be as efficient in rendering as possible.
With the previous implementation there were limitations:
- there was no way to turn off caching (`load_file` was always used)
- every render call not only looked up the cache file path but checked
  to make sure its parent dir existed and created it if it did not.

Having that extra logic on each render call is really expensive.  Maybe,
in a production setting, you are ok with the default `load_file` behavior
of caching templates alongside the source files but in dev mode you
want to cache to a root that isn't under version control (b/c you
don't want to check in cached templates).  These changes can support
that workflow:

``` ruby
Deas::TemplateSource.new(path.to_s).tap do |s|
  s.engine('erb', Deas::Erubis::TemplateEngine, {
    'cache' => production? ? true : root.join('/tmp/view_handlers')
  })
end
```

Plus these changes can support a workflow that says "cache in production
but not in development":

``` ruby
Deas::TemplateSource.new(path.to_s).tap do |s|
  s.engine('erb', Deas::Erubis::TemplateEngine, {
    'cache' => production?
  })
end
```

Overall, this gives the user more options about caching so that they
can optimize the settings for their environment.

To accomplish this in the most efficient manner and to avoid doing
a bunch of conditional logic on each render call, the source defines
a not implemented `eruby` method that gets overridden per instance
on init.  This is done by defining an `eruby` method on the metaclass
and doing the conditional logic once on init to determine what the
meta-method's logic will be.
