### PR TITLE
partial method implementation

### DIFF
--- a/lib/deas-erubis.rb
+++ b/lib/deas-erubis.rb
@@ -27,14 +27,15 @@ module Deas::Erubis
       @erb_logger_local ||= (self.opts['logger_local'] || DEFAULT_LOGGER_LOCAL)
     end
 
+    # render the template with any handler layouts; include the handler as a local
     def render(template_name, view_handler, locals)
       # TODO: look at view handler layouts and render in them??
       self.erb_source.render(template_name, render_locals(view_handler, locals))
     end
 
+    # render the template against the given locals
     def partial(template_name, locals)
-      # TODO: render template with given context locals
-      raise NotImplementedError
+      self.erb_source.render(template_name, locals)
     end
 
     def capture_partial(template_name, locals, &content)

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -23,4 +23,9 @@ module Factory
     "<p>logger: #{engine.logger.to_s}</p>\n"
   end
 
+  def self.partial_erb_rendered(engine, locals)
+    "<h1>local1: #{locals['local1']}</h1>\n"\
+    "<p>logger: #{engine.logger.to_s}</p>\n"
+  end
+
 end

--- a/test/support/templates/_partial.erb
+++ b/test/support/templates/_partial.erb
@@ -1,0 +1,2 @@
+<h1>local1: <%= local1 %></h1>
+<p>logger: <%= logger %></p>

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -59,10 +59,8 @@ class Deas::Erubis::TemplateEngine
       assert_equal logger_local, engine.erb_logger_local
     end
 
-    should "render erb templates" do
-      engine = Deas::Erubis::TemplateEngine.new({
-        'source_path' => TEMPLATE_ROOT
-      })
+    should "render templates" do
+      engine = Deas::Erubis::TemplateEngine.new('source_path' => TEMPLATE_ROOT)
       view_handler = OpenStruct.new({
         :identifier => Factory.integer,
         :name => Factory.string
@@ -73,15 +71,17 @@ class Deas::Erubis::TemplateEngine
       assert_equal exp, engine.render('view', view_handler, locals)
     end
 
-    should "not implement the engine partial method" do
-      assert_raises NotImplementedError do
-        subject.partial('_partial.erb', {})
-      end
+    should "render partial templates" do
+      engine = Deas::Erubis::TemplateEngine.new('source_path' => TEMPLATE_ROOT)
+      locals = { 'local1' => Factory.string }
+      exp = Factory.partial_erb_rendered(engine, locals).to_s
+
+      assert_equal exp, engine.partial('_partial', locals)
     end
 
     should "not implement the engine capture partial method" do
       assert_raises NotImplementedError do
-        subject.capture_partial('_partial.erb', {})
+        subject.capture_partial('_partial', {})
       end
     end
 


### PR DESCRIPTION
This implements the `partial` engine API method.  This method is used
to render a template against a set of locals.  Unlike the `render`
method, it is agnostic of any view handler.

This is part of implementing Deas' render api.

@jcredding ready for review.
