### PR TITLE
have the given `'deas_template_source'` engine opt as a context ivar

### DIFF
--- a/lib/deas-erubis.rb
+++ b/lib/deas-erubis.rb
@@ -15,6 +15,7 @@ module Deas::Erubis
       @erb_source ||= Source.new(self.source_path, {
         :eruby          => self.opts['eruby'],
         :cache          => self.opts['cache'],
+        :deas_source    => self.opts['deas_template_source'],
         :default_locals => { self.erb_logger_local => self.logger }
       })
     end

--- a/lib/deas-erubis/source.rb
+++ b/lib/deas-erubis/source.rb
@@ -53,6 +53,7 @@ module Deas::Erubis
         end
       end
 
+      @deas_source   = opts[:deas_source]
       @context_class = build_context_class(opts)
     end
 
@@ -65,7 +66,7 @@ module Deas::Erubis
     end
 
     def render(file_name, locals)
-      eruby(file_name).evaluate(@context_class.new(locals))
+      eruby(file_name).evaluate(@context_class.new(@deas_source, locals))
     end
 
     def inspect
@@ -95,10 +96,13 @@ module Deas::Erubis
 
     def build_context_class(opts)
       Class.new do
+        # TODO: add in partial helpers to use @deas_source
         # TODO: mixin context helpers? `opts[:template_helpers]`
         (opts[:default_locals] || {}).each{ |k, v| define_method(k){ v } }
 
-        def initialize(locals)
+        def initialize(deas_source, locals)
+          @deas_source = deas_source
+
           metaclass = class << self; self; end
           metaclass.class_eval do
             locals.each do |key, value|

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -39,6 +39,16 @@ class Deas::Erubis::TemplateEngine
       assert_equal TEMPLATE_CACHE_ROOT.to_s, engine.erb_source.cache_root.to_s
     end
 
+    should "pass any given deas template source to its source" do
+      deas_source = 'a-deas-source'
+      source_opts = nil
+
+      Assert.stub(Deas::Erubis::Source, :new){ |root, opts| source_opts = opts }
+      Deas::Erubis::TemplateEngine.new('deas_template_source' => deas_source).erb_source
+
+      assert_equal deas_source, source_opts[:deas_source]
+    end
+
     should "use 'view' as the handler local name by default" do
       assert_equal 'view', subject.erb_handler_local
     end


### PR DESCRIPTION
This updates the source to allow passing the `'dea_template_source'`
engine option down to the context class intances it renders the
templates against.  This means the deas template source is exposed
to the templates as the ivar `@deas_source`.

This is needed to implement template helpers that render other
templates (ie `partial` and `capture_partial`).  These helpers need
to have access to all the rendering behavior that a top-level Deas
render call would have.  To do this they need access to the deas
template source in use.

Specifically, this will allow rendering partial templates that require
a different engine and also rendering templates that use multiple engines.
Without this, you could only render erb templates from an erb template.

@jcredding ready for review.
