### PR TITLE
implement new Deas `compile` api method

### DIFF
--- a/lib/deas-erubis.rb
+++ b/lib/deas-erubis.rb
@@ -43,6 +43,10 @@ module Deas::Erubis
       raise NotImplementedError
     end
 
+    def compile(template_name, compiled_content)
+      self.erb_source.compile(template_name, compiled_content)
+    end
+
     private
 
     def render_locals(view_handler, locals)

--- a/lib/deas-erubis/source.rb
+++ b/lib/deas-erubis/source.rb
@@ -69,6 +69,13 @@ module Deas::Erubis
       eruby(file_name).evaluate(@context_class.new(@deas_source, locals), &content)
     end
 
+    def compile(file_name, content)
+      @eruby_class.new(content, {
+        :bufvar   => BUFVAR_NAME,
+        :filename => file_name
+      }).evaluate(@context_class.new(@deas_source, {}))
+    end
+
     def inspect
       "#<#{self.class}:#{'0x0%x' % (object_id << 1)}"\
       " @root=#{@root.inspect}"\

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -46,4 +46,10 @@ module Factory
     "</div>\n"
   end
 
+  def self.compile_erb_rendered(engine)
+    "<h1>compile</h1>\n"\
+    "<p>2</p>\n"\
+    "<p>logger: #{engine.logger.to_s}</p>\n"
+  end
+
 end

--- a/test/support/templates/compile.erb
+++ b/test/support/templates/compile.erb
@@ -1,0 +1,3 @@
+<h1>compile</h1>
+<p><%= 1 + 1 %></p>
+<p>logger: <%= logger %></p>

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -36,7 +36,7 @@ class Deas::Erubis::Source
     subject{ @source }
 
     should have_readers :root, :cache_root, :eruby_class, :context_class
-    should have_imeths :eruby, :render
+    should have_imeths :eruby, :render, :compile
 
     should "know its root" do
       assert_equal @root, subject.root.to_s
@@ -121,13 +121,12 @@ class Deas::Erubis::Source
       }
     end
     teardown do
-      Dir.glob(TEMPLATE_ROOT.join("*#{@source_class::CACHE_EXT}").to_s).each do |f|
-        FileUtils.rm_f(f)
-      end
-      Dir.glob(TEMPLATE_CACHE_ROOT.join("*#{@source_class::CACHE_EXT}").to_s).each do |f|
-        FileUtils.rm_f(f)
-      end
+      root = TEMPLATE_ROOT.join("*#{@source_class::CACHE_EXT}").to_s
+      Dir.glob(root).each{ |f| FileUtils.rm_f(f) }
+      root = TEMPLATE_CACHE_ROOT.join("*#{@source_class::CACHE_EXT}").to_s
+      Dir.glob(root).each{ |f| FileUtils.rm_f(f) }
     end
+
   end
 
   class RenderTests < RenderSetupTests
@@ -192,7 +191,7 @@ class Deas::Erubis::Source
   class RenderNoCacheTests < RenderTests
     desc "when caching is disabled"
     setup do
-      @source = @source_class.new(@root, :cache => TEMPLATE_CACHE_ROOT)
+      @source = @source_class.new(@root, :cache => false)
     end
 
     should "not cache templates" do
@@ -216,6 +215,17 @@ class Deas::Erubis::Source
     should "render the template for the given file name and return its data" do
       exp = Factory.yield_erb_rendered(@file_locals, &@content)
       assert_equal exp, subject.render(@file_name, @file_locals, &@content)
+    end
+
+  end
+
+  class CompileTests < RenderSetupTests
+    desc "`compile` method"
+
+    should "compile raw content file name and return its data" do
+      raw = "<p><%= 1 + 1 %></p>"
+      exp = "<p>2</p>"
+      assert_equal exp, subject.compile('compile', raw)
     end
 
   end

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -76,8 +76,8 @@ class Deas::Erubis::TemplateEngine
         :name => Factory.string
       })
       locals = { 'local1' => Factory.string }
-      exp = Factory.view_erb_rendered(engine, view_handler, locals).to_s
 
+      exp = Factory.view_erb_rendered(engine, view_handler, locals).to_s
       assert_equal exp, engine.render('view', view_handler, locals)
     end
 
@@ -97,8 +97,8 @@ class Deas::Erubis::TemplateEngine
     should "render partial templates" do
       engine = Deas::Erubis::TemplateEngine.new('source_path' => TEMPLATE_ROOT)
       locals = { 'local1' => Factory.string }
-      exp = Factory.partial_erb_rendered(engine, locals).to_s
 
+      exp = Factory.partial_erb_rendered(engine, locals).to_s
       assert_equal exp, engine.partial('_partial', locals)
     end
 
@@ -106,6 +106,16 @@ class Deas::Erubis::TemplateEngine
       assert_raises NotImplementedError do
         subject.capture_partial('_partial', {})
       end
+    end
+
+    should "compile raw template markup" do
+      engine = Deas::Erubis::TemplateEngine.new('source_path' => TEMPLATE_ROOT)
+      file_name = 'compile'
+      file_path = TEMPLATE_ROOT.join("#{file_name}#{Deas::Erubis::Source::EXT}").to_s
+      file_content = File.read(file_path)
+
+      exp = Factory.compile_erb_rendered(engine).to_s
+      assert_equal exp, engine.compile(file_name, file_content)
     end
 
   end


### PR DESCRIPTION
This implements the `compile` method from the updated Deas render API.
This method takes raw content and renders it against the given locals.

This allows deas-erubis to be used as a downstream engine when rendering
a template with multiple engines.  It is difficult to envision a
scenario where deas-erubis wouldn't be the top-level engine, but
this in theory supports it.  In most cases, however, deas-erubis
should be used as the top-level engine that renders to other downstream
template markups like Markdown, Scss, Coffee etc.

Note: this also does some cleanups on the source tests.  There was
a poorly styled context and the render no cache context was setup
incorrectly.

@jcredding ready for review.