### PR TITLE
render with a given content block

### DIFF
--- a/lib/deas-erubis.rb
+++ b/lib/deas-erubis.rb
@@ -28,10 +28,9 @@ module Deas::Erubis
       @erb_logger_local ||= (self.opts['logger_local'] || DEFAULT_LOGGER_LOCAL)
     end
 
-    # render the template with any handler layouts; include the handler as a local
-    def render(template_name, view_handler, locals)
-      # TODO: look at view handler layouts and render in them??
-      self.erb_source.render(template_name, render_locals(view_handler, locals))
+    # render the template including the handler as a local
+    def render(template_name, view_handler, locals, &content)
+      self.erb_source.render(template_name, render_locals(view_handler, locals), &content)
     end
 
     # render the template against the given locals

--- a/lib/deas-erubis/source.rb
+++ b/lib/deas-erubis/source.rb
@@ -65,8 +65,8 @@ module Deas::Erubis
       raise NotImplementedError
     end
 
-    def render(file_name, locals)
-      eruby(file_name).evaluate(@context_class.new(@deas_source, locals))
+    def render(file_name, locals, &content)
+      eruby(file_name).evaluate(@context_class.new(@deas_source, locals), &content)
     end
 
     def inspect

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -28,4 +28,22 @@ module Factory
     "<p>logger: #{engine.logger.to_s}</p>\n"
   end
 
+  def self.yield_erb_rendered(locals, &content)
+    "<h1>name: #{locals['name']}</h1>\n"\
+    "<h2>local1: #{locals['local1']}</h2>\n"\
+    "<div>\n"\
+    "  #{content.call}\n"\
+    "</div>\n"
+  end
+
+  def self.yield_view_erb_rendered(engine, view_handler, locals, &content)
+    "<h1>name: #{view_handler.name}</h1>\n"\
+    "<h2>local1: #{locals['local1']}</h2>\n"\
+    "<p>id: #{view_handler.identifier}</p>\n"\
+    "<p>logger: #{engine.logger.to_s}</p>\n"\
+    "<div>\n"\
+    "  #{content.call}\n"\
+    "</div>\n"
+  end
+
 end

--- a/test/support/templates/yield.erb
+++ b/test/support/templates/yield.erb
@@ -1,0 +1,5 @@
+<h1>name: <%= name %></h1>
+<h2>local1: <%= local1 %></h2>
+<div>
+  <%= yield %>
+</div>

--- a/test/support/templates/yield_view.erb
+++ b/test/support/templates/yield_view.erb
@@ -1,0 +1,7 @@
+<h1>name: <%= view.name %></h1>
+<h2>local1: <%= local1 %></h2>
+<p>id: <%= view.identifier %></p>
+<p>logger: <%= logger %></p>
+<div>
+  <%= yield %>
+</div>

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -206,6 +206,20 @@ class Deas::Erubis::Source
 
   end
 
+  class RenderContentTests < RenderTests
+    desc "when yielding to a given content block"
+    setup do
+      @file_name = "yield"
+      @content = Proc.new{ "<span>some content</span>" }
+    end
+
+    should "render the template for the given file name and return its data" do
+      exp = Factory.yield_erb_rendered(@file_locals, &@content)
+      assert_equal exp, subject.render(@file_name, @file_locals, &@content)
+    end
+
+  end
+
   class DefaultSource < UnitTests
     desc "DefaultSource"
     setup do

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -81,6 +81,19 @@ class Deas::Erubis::TemplateEngine
       assert_equal exp, engine.render('view', view_handler, locals)
     end
 
+    should "render templates yielding to given content blocks" do
+      engine = Deas::Erubis::TemplateEngine.new('source_path' => TEMPLATE_ROOT)
+      view_handler = OpenStruct.new({
+        :identifier => Factory.integer,
+        :name => Factory.string
+      })
+      locals = { 'local1' => Factory.string }
+      content = Proc.new{ "<span>some content</span>" }
+      exp = Factory.yield_view_erb_rendered(engine, view_handler, locals, &content).to_s
+
+      assert_equal exp, engine.render('yield_view', view_handler, locals, &content)
+    end
+
     should "render partial templates" do
       engine = Deas::Erubis::TemplateEngine.new('source_path' => TEMPLATE_ROOT)
       locals = { 'local1' => Factory.string }


### PR DESCRIPTION
This updates the render API to take an optional content block and
support yielding to it.  This implements layouts rendering.

Note: this removes the comments about looking at the handler and
handling any layouts.  Deas is going to do this.  This is a better
approach both because it centralizes the logic of building layout
content blocks and also each engine doesn't have to reimplement it.
Engines that don't want/need to support layouts can just ignore any
given content blocks.

See redding/deas#159 for reference.

@jcredding ready for review.