### PR TITLE
add `partial` and `capture_partial` template helpers

### DIFF
--- a/lib/deas-erubis.rb
+++ b/lib/deas-erubis.rb
@@ -1,8 +1,8 @@
 require 'deas/template_engine'
 require 'erubis'
 
-require "deas-erubis/version"
-require "deas-erubis/source"
+require 'deas-erubis/version'
+require 'deas-erubis/source'
 
 module Deas::Erubis
 
@@ -34,13 +34,8 @@ module Deas::Erubis
     end
 
     # render the template against the given locals
-    def partial(template_name, locals)
-      self.erb_source.render(template_name, locals)
-    end
-
-    def capture_partial(template_name, locals, &content)
-      # TODO: render template with given locals yielding to given content
-      raise NotImplementedError
+    def partial(template_name, locals, &content)
+      self.erb_source.render(template_name, locals, &content)
     end
 
     def compile(template_name, compiled_content)

--- a/lib/deas-erubis/source.rb
+++ b/lib/deas-erubis/source.rb
@@ -1,5 +1,6 @@
 require 'pathname'
 require 'erubis'
+require 'deas-erubis/template_helpers'
 
 module Deas; end
 module Deas::Erubis
@@ -103,7 +104,7 @@ module Deas::Erubis
 
     def build_context_class(opts)
       Class.new do
-        # TODO: add in partial helpers to use @deas_source
+        include ::Deas::Erubis::TemplateHelpers
         # TODO: mixin context helpers? `opts[:template_helpers]`
         (opts[:default_locals] || {}).each{ |k, v| define_method(k){ v } }
 

--- a/lib/deas-erubis/template_helpers.rb
+++ b/lib/deas-erubis/template_helpers.rb
@@ -1,0 +1,58 @@
+require 'deas-erubis/source'
+
+module Deas; end
+module Deas::Erubis
+
+  module TemplateHelpers
+
+    def self.included(receiver)
+      receiver.class_eval{ include Methods }
+    end
+
+    module Methods
+
+      def partial(*args)
+        @deas_source.partial(*args)
+      end
+
+      def capture_partial(*args, &content)
+        _erb_buffer @deas_source.partial(*args, &Proc.new{ _erb_capture(&content) })
+      end
+
+      private
+
+      def _erb_capture(&content)
+        begin
+          # copy original buffer state
+          orig_buf_value = _erb_bufvar
+          instance_variable_set(_erb_bufvar_name, "\n")
+
+          # evaluate the given content
+          result = instance_eval(&content)
+          new_buf_value = _erb_bufvar
+
+          # return result if nothing buffered; otherwise return what was buffered
+          new_buf_value == "\n" ? "\n#{result}" : new_buf_value
+        ensure
+          # reset buffer to original state
+          instance_variable_set(_erb_bufvar_name, orig_buf_value)
+        end
+      end
+
+      def _erb_buffer(content)
+        _erb_bufvar << content
+      end
+
+      def _erb_bufvar
+        instance_variable_get(_erb_bufvar_name)
+      end
+
+      def _erb_bufvar_name
+        Deas::Erubis::Source::BUFVAR_NAME
+      end
+
+    end
+
+  end
+
+end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -16,24 +16,19 @@ module Factory
     "<h2>local1: #{locals['local1']}</h2>\n"
   end
 
-  def self.view_erb_rendered(engine, view_handler, locals)
-    "<h1>name: #{view_handler.name}</h1>\n"\
-    "<h2>local1: #{locals['local1']}</h2>\n"\
-    "<p>id: #{view_handler.identifier}</p>\n"\
-    "<p>logger: #{engine.logger.to_s}</p>\n"
-  end
-
-  def self.partial_erb_rendered(engine, locals)
-    "<h1>local1: #{locals['local1']}</h1>\n"\
-    "<p>logger: #{engine.logger.to_s}</p>\n"
-  end
-
   def self.yield_erb_rendered(locals, &content)
     "<h1>name: #{locals['name']}</h1>\n"\
     "<h2>local1: #{locals['local1']}</h2>\n"\
     "<div>\n"\
     "  #{content.call}\n"\
     "</div>\n"
+  end
+
+  def self.view_erb_rendered(engine, view_handler, locals)
+    "<h1>name: #{view_handler.name}</h1>\n"\
+    "<h2>local1: #{locals['local1']}</h2>\n"\
+    "<p>id: #{view_handler.identifier}</p>\n"\
+    "<p>logger: #{engine.logger.to_s}</p>\n"
   end
 
   def self.yield_view_erb_rendered(engine, view_handler, locals, &content)
@@ -43,6 +38,40 @@ module Factory
     "<p>logger: #{engine.logger.to_s}</p>\n"\
     "<div>\n"\
     "  #{content.call}\n"\
+    "</div>\n"
+  end
+
+  def self.partial_erb_rendered(engine, locals)
+    "<h1>local1: #{locals['local1']}</h1>\n"\
+    "<p>logger: #{engine.logger.to_s}</p>\n"
+  end
+
+  def self.yield_partial_erb_rendered(engine, locals, &content)
+    "<h1>local1: #{locals['local1']}</h1>\n"\
+    "<p>logger: #{engine.logger.to_s}</p>\n"\
+    "<div>\n"\
+    "  #{content.call}\n"\
+    "</div>\n"
+  end
+
+  def self.partial_with_partial_erb_rendered(engine, locals)
+    "<div>\n"\
+    "  <h1>local1: #{locals['local1']}</h1>\n"\
+    "<p>logger: #{engine.logger.to_s}</p>\n\n"\
+    "</div>\n"
+  end
+
+  def self.partial_with_capture_partial_erb_rendered(engine, locals)
+    "<div>\n"\
+    "<h1>local1: #{locals['local1']}</h1>\n"\
+    "<p>logger: #{engine.logger.to_s}</p>\n"\
+    "<div>\n"\
+    "  \n"\
+    "    <span>some content</span>\n"\
+    "\n"\
+    "</div>\n"\
+    "<h1>local1: #{locals['local1']}</h1>\n"\
+    "<p>logger: #{engine.logger.to_s}</p>\n"\
     "</div>\n"
   end
 

--- a/test/support/templates/_yield_partial.erb
+++ b/test/support/templates/_yield_partial.erb
@@ -1,0 +1,5 @@
+<h1>local1: <%= local1 %></h1>
+<p>logger: <%= logger %></p>
+<div>
+  <%= yield %>
+</div>

--- a/test/support/templates/with_capture_partial.erb
+++ b/test/support/templates/with_capture_partial.erb
@@ -1,0 +1,6 @@
+<div>
+  <% capture_partial '_yield_partial', 'local1' => local1 do %>
+    <span>some content</span>
+  <% end %>
+  <% capture_partial '_partial', 'local1' => local1 %>
+</div>

--- a/test/support/templates/with_partial.erb
+++ b/test/support/templates/with_partial.erb
@@ -1,0 +1,3 @@
+<div>
+  <%= partial '_partial', 'local1' => local1 %>
+</div>

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -85,6 +85,14 @@ class Deas::Erubis::Source
       assert_instance_of ::Class, subject.context_class
     end
 
+    should "mixin template helpers to its context class" do
+      assert_includes Deas::Erubis::TemplateHelpers, subject.context_class
+
+      context = subject.context_class.new('deas-source', {})
+      assert_responds_to :partial, context
+      assert_responds_to :capture_partial, context
+    end
+
     should "optionally take and apply default locals to its context class" do
       local_name, local_val = [Factory.string, Factory.string]
       source = @source_class.new(@root, {


### PR DESCRIPTION
This adds template helpers for rendering partials from other templates.
This covers both standard partials and partials that yield to given
content blocks.

This also removes support for an engine `capture_partial` method and
updates `partial` to take an optional content block (similar to the
`render` method.  This change makes `capture_partial` unnecessary.

Note: the tests need to be cleaned up a bit (which I'll do in a
coming PR).  They are doing way too many "system" tests in the unit
tests.  Plus having to add the `DeasSourceSpy` is not ideal.  Once
a new Deas rolls with the proper render API, I'll bring it in and
use its source directly and split out the system tests from the
unit tests.

@jcredding ready for review.