### PR TITLE
switch to in-memory template caching

### DIFF
--- a/lib/deas-erubis/source.rb
+++ b/lib/deas-erubis/source.rb
@@ -8,73 +8,33 @@ module Deas::Erubis
   class Source
 
     EXT           = '.erb'.freeze
-    CACHE_EXT     = '.cache'.freeze
     BUFVAR_NAME   = '@_erb_buf'.freeze
     DEFAULT_ERUBY = ::Erubis::Eruby
 
-    attr_reader :root, :cache_root, :eruby_class, :context_class
+    attr_reader :root, :eruby_class, :cache, :context_class
 
     def initialize(root, opts)
-      @root        = Pathname.new(root.to_s)
-      @eruby_class = opts[:eruby] || DEFAULT_ERUBY
-
-      should_cache = !!opts[:cache]
-      @cache_root  = opts[:cache] == true ? @root : Pathname.new(opts[:cache].to_s)
-      @cache_root.mkpath if should_cache && !@cache_root.exist?
-
-      if should_cache
-        # use `load_file` to lookup and cache templates (faster renders)
-        if @cache_root == @root
-          # use the `load_file` default and don't bother with looking up, setting,
-          # and making sure the cache file path exists - by default `load_file`
-          # caches alongside the source with the `CACHE_EXT` appended.
-          add_meta_eruby_method do |file_name|
-            @eruby_class.load_file(source_file_path(file_name), {
-              :bufvar => BUFVAR_NAME
-            })
-          end
-        else
-          # lookup and ensure the custom cache location exists (more expensive)
-          add_meta_eruby_method do |file_name|
-            @eruby_class.load_file(source_file_path(file_name), {
-              :bufvar    => BUFVAR_NAME,
-              :cachename => cache_file_path(file_name)
-            })
-          end
-        end
-      else
-        # don't cache template files (slower renders, but no cache files created)
-        add_meta_eruby_method do |file_name|
-          filename = source_file_path(file_name).to_s
-          template = File.send(File.respond_to?(:binread) ? :binread : :read, filename)
-          @eruby_class.new(template, {
-            :bufvar   => BUFVAR_NAME,
-            :filename => filename
-          })
-        end
-      end
-
-      @deas_source   = opts[:deas_source]
+      @root          = Pathname.new(root.to_s)
+      @eruby_class   = opts[:eruby] || DEFAULT_ERUBY
+      @cache         = opts[:cache] ? Hash.new : NullCache.new
       @context_class = build_context_class(opts)
-    end
 
-    def eruby(file_name)
-      # should be overridden by a metaclass equivalent on init
-      # the implementation changes whether you are caching templates or not
-      # and the goal here is to not add a bunch of conditional overhead as this
-      # will be called on every render
-      raise NotImplementedError
+      @deas_source = opts[:deas_source]
     end
 
     def render(file_name, locals, &content)
-      eruby(file_name).evaluate(@context_class.new(@deas_source, locals), &content)
+      load(file_name).evaluate(@context_class.new(@deas_source, locals), &content)
     end
 
-    def compile(file_name, content)
+    def compile(filename, content)
+      eruby(filename, content).evaluate(@context_class.new(@deas_source, {}))
+    end
+
+    def eruby(filename, content)
       @eruby_class.new(content, {
         :bufvar   => BUFVAR_NAME,
-        :filename => file_name
-      }).evaluate(@context_class.new(@deas_source, {}))
+        :filename => filename
+      })
     end
 
     def inspect
@@ -85,21 +45,16 @@ module Deas::Erubis
 
     private
 
+    def load(file_name)
+      @cache[file_name] ||= begin
+        filename = source_file_path(file_name).to_s
+        content = File.send(File.respond_to?(:binread) ? :binread : :read, filename)
+        eruby(filename, content)
+      end
+    end
+
     def source_file_path(file_name)
       self.root.join("#{file_name}#{EXT}").to_s
-    end
-
-    def cache_file_path(file_name)
-      self.cache_root.join("#{file_name}#{EXT}#{CACHE_EXT}").tap do |path|
-        path.dirname.mkpath if !path.dirname.exist?
-      end.to_s
-    end
-
-    def add_meta_eruby_method(&method)
-      metaclass = class << self; self; end
-      metaclass.class_eval do
-        define_method(:eruby, &method)
-      end
     end
 
     def build_context_class(opts)
@@ -119,6 +74,12 @@ module Deas::Erubis
           end
         end
       end
+    end
+
+    class NullCache
+      def [](file_name);         end
+      def []=(file_name, value); end
+      def keys; [];              end
     end
 
   end

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -34,9 +34,9 @@ class Deas::Erubis::TemplateEngine
       assert_equal custom_eruby, engine.erb_source.eruby_class
     end
 
-    should "allow custom cache roots on its source" do
-      engine = Deas::Erubis::TemplateEngine.new('cache' => TEMPLATE_CACHE_ROOT)
-      assert_equal TEMPLATE_CACHE_ROOT.to_s, engine.erb_source.cache_root.to_s
+    should "pass any given cache option to its source" do
+      engine = Deas::Erubis::TemplateEngine.new('cache' => true)
+      assert_kind_of Hash, engine.erb_source.cache
     end
 
     should "pass any given deas template source to its source" do


### PR DESCRIPTION
After benchmarking, the Erubis file caching made no difference in
req/s benchmarks.  However, switching to in-memory caching of eruby
instances made a significant performance improvement.

This removes all the cache root file caching meta eruby method logic
and instead switches to an in-memory cache.  You can choose to cache
or not.

@jcredding ready for review.