### PR TITLE
update template helpers to take explicit arguments

### DIFF
--- a/lib/deas-erubis/template_helpers.rb
+++ b/lib/deas-erubis/template_helpers.rb
@@ -11,12 +11,12 @@ module Deas::Erubis
 
     module Methods
 
-      def partial(*args)
-        @deas_source.partial(*args)
+      def partial(n, l = nil)
+        @deas_source.partial(n, l || {})
       end
 
-      def capture_partial(*args, &content)
-        _erb_buffer @deas_source.partial(*args, &Proc.new{ _erb_capture(&content) })
+      def capture_partial(n, l = nil, &c)
+        _erb_buffer @deas_source.partial(n, l || {}, &Proc.new{ _erb_capture(&c) })
       end
 
       private

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -58,6 +58,7 @@ module Factory
     "<div>\n"\
     "  <h1>local1: #{locals['local1']}</h1>\n"\
     "<p>logger: #{engine.logger.to_s}</p>\n\n"\
+    "  <span>No locals!</span>\n\n"\
     "</div>\n"
   end
 
@@ -72,6 +73,7 @@ module Factory
     "</div>\n"\
     "<h1>local1: #{locals['local1']}</h1>\n"\
     "<p>logger: #{engine.logger.to_s}</p>\n"\
+    "<span>No locals!</span>\n"\
     "</div>\n"
   end
 

--- a/test/support/templates/_partial_no_locals.erb
+++ b/test/support/templates/_partial_no_locals.erb
@@ -1,0 +1,1 @@
+<span>No locals!</span>

--- a/test/support/templates/with_capture_partial.erb
+++ b/test/support/templates/with_capture_partial.erb
@@ -3,4 +3,5 @@
     <span>some content</span>
   <% end %>
   <% capture_partial '_partial', 'local1' => local1 %>
+  <% capture_partial '_partial_no_locals' %>
 </div>

--- a/test/support/templates/with_partial.erb
+++ b/test/support/templates/with_partial.erb
@@ -1,3 +1,4 @@
 <div>
   <%= partial '_partial', 'local1' => local1 %>
+  <%= partial '_partial_no_locals' %>
 </div>

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -102,7 +102,7 @@ class Deas::Erubis::Source
       assert_equal local_val, context.send(local_name)
     end
 
-    should "set any deas source given to its context class as in ivar on init" do
+    should "set any deas source given to its context class as an ivar on init" do
       deas_source = 'a-deas-source'
       context = subject.context_class.new(deas_source, {})
 


### PR DESCRIPTION
Before we were just lazily passing on whatever was given.  However,
this fails if called with no locals as the deas source expects locals
to be passed.

This updates the template helpers to default the locals to `{}` if
none are specified.  This was missed in the original tests as no
templates called the helpers without locals.  This updates the tests
to cover this case.

@jcredding ready for review.  I noticed this when benchmarking.  I noticed this case ran really fast and transferred much less content.  Something seemed fishy so I dug deeper and found this bug.  Huzzah!