### PR TITLE
source partial and capture partial template helpers

### DIFF
--- a/lib/deas-erubis/template_helpers.rb
+++ b/lib/deas-erubis/template_helpers.rb
@@ -11,12 +11,20 @@ module Deas::Erubis
 
     module Methods
 
-      def partial(n, l = nil)
-        @deas_source.partial(n, l || {})
+      def partial(name, locals = nil)
+        source_partial(@deas_source, name, locals)
       end
 
-      def capture_partial(n, l = nil, &c)
-        _erb_buffer @deas_source.partial(n, l || {}, &Proc.new{ _erb_capture(&c) })
+      def capture_partial(name, locals = nil, &c)
+        source_capture_partial(@deas_source, name, locals, &c)
+      end
+
+      def source_partial(source, name, locals = nil)
+        source.partial(name, locals || {})
+      end
+
+      def source_capture_partial(source, name, locals = nil, &c)
+        _erb_buffer source.partial(name, locals || {}, &Proc.new{ _erb_capture(&c) })
       end
 
       private

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -59,6 +59,7 @@ module Factory
     "  <h1>local1: #{locals['local1']}</h1>\n"\
     "<p>logger: #{engine.logger.to_s}</p>\n\n"\
     "  <span>No locals!</span>\n\n"\
+    "  <span>No locals!</span>\n\n"\
     "</div>\n"
   end
 
@@ -73,6 +74,7 @@ module Factory
     "</div>\n"\
     "<h1>local1: #{locals['local1']}</h1>\n"\
     "<p>logger: #{engine.logger.to_s}</p>\n"\
+    "<span>No locals!</span>\n"\
     "<span>No locals!</span>\n"\
     "</div>\n"
   end

--- a/test/support/templates/with_capture_partial.erb
+++ b/test/support/templates/with_capture_partial.erb
@@ -4,4 +4,5 @@
   <% end %>
   <% capture_partial '_partial', 'local1' => local1 %>
   <% capture_partial '_partial_no_locals' %>
+  <% source_capture_partial @deas_source, '_partial_no_locals' %>
 </div>

--- a/test/support/templates/with_partial.erb
+++ b/test/support/templates/with_partial.erb
@@ -1,4 +1,5 @@
 <div>
   <%= partial '_partial', 'local1' => local1 %>
   <%= partial '_partial_no_locals' %>
+  <%= source_partial @deas_source, '_partial_no_locals' %>
 </div>

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -81,6 +81,8 @@ class Deas::Erubis::Source
       context = subject.context_class.new('deas-source', {})
       assert_responds_to :partial, context
       assert_responds_to :capture_partial, context
+      assert_responds_to :source_partial, context
+      assert_responds_to :source_capture_partial, context
     end
 
     should "optionally take and apply default locals to its context class" do


### PR DESCRIPTION
These adds template helpers for partial rendering where you inject
the template source to render against.  This is designed so that
3rd-party tools can define their own template sources and then
define template helpers that render using them.

This also updates the standard helpers to just call these injecting
`@deas_source`.  This is part of supporting 3rd-party template helpers.

@jcredding ready for review.