### PR TITLE
rename the source locals option to `:locals`

### DIFF
--- a/lib/deas-erubis.rb
+++ b/lib/deas-erubis.rb
@@ -13,10 +13,10 @@ module Deas::Erubis
 
     def erb_source
       @erb_source ||= Source.new(self.source_path, {
-        :eruby          => self.opts['eruby'],
-        :cache          => self.opts['cache'],
-        :deas_source    => self.opts['deas_template_source'],
-        :default_locals => { self.erb_logger_local => self.logger }
+        :eruby       => self.opts['eruby'],
+        :cache       => self.opts['cache'],
+        :deas_source => self.opts['deas_template_source'],
+        :locals      => { self.erb_logger_local => self.logger }
       })
     end
 

--- a/lib/deas-erubis/source.rb
+++ b/lib/deas-erubis/source.rb
@@ -61,7 +61,7 @@ module Deas::Erubis
       Class.new do
         include ::Deas::Erubis::TemplateHelpers
         # TODO: mixin context helpers? `opts[:template_helpers]`
-        (opts[:default_locals] || {}).each{ |k, v| define_method(k){ v } }
+        (opts[:locals] || {}).each{ |k, v| define_method(k){ v } }
 
         def initialize(deas_source, locals)
           @deas_source = deas_source

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -86,7 +86,7 @@ class Deas::Erubis::Source
     should "optionally take and apply default locals to its context class" do
       local_name, local_val = [Factory.string, Factory.string]
       source = @source_class.new(@root, {
-        :default_locals => { local_name => local_val }
+        :locals => { local_name => local_val }
       })
       context = source.context_class.new('deas-source', {})
 


### PR DESCRIPTION
This gets it more inline with how Nm names its source option.  Also
this is less typing.  This is just a cleanup - no external api
changes.

@jcredding ready for review.