### PR TITLE
`'helpers'` opt - include custom template helpers on context class

### DIFF
--- a/lib/deas-erubis.rb
+++ b/lib/deas-erubis.rb
@@ -16,6 +16,7 @@ module Deas::Erubis
         :eruby       => self.opts['eruby'],
         :cache       => self.opts['cache'],
         :deas_source => self.opts['deas_template_source'],
+        :helpers     => self.opts['helpers'],
         :locals      => { self.erb_logger_local => self.logger }
       })
     end

--- a/lib/deas-erubis/source.rb
+++ b/lib/deas-erubis/source.rb
@@ -60,8 +60,8 @@ module Deas::Erubis
     def build_context_class(opts)
       Class.new do
         include ::Deas::Erubis::TemplateHelpers
-        # TODO: mixin context helpers? `opts[:template_helpers]`
-        (opts[:locals] || {}).each{ |k, v| define_method(k){ v } }
+        (opts[:helpers] || []).each{ |helper| include helper }
+        (opts[:locals]  || {}).each{ |k, v| define_method(k){ v } }
 
         def initialize(deas_source, locals)
           @deas_source = deas_source

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -85,6 +85,15 @@ class Deas::Erubis::Source
       assert_responds_to :source_capture_partial, context
     end
 
+    should "mixin custom template helpers to its context class" do
+      source = @source_class.new(@root, :helpers => [SomeCustomHelpers])
+
+      assert_includes SomeCustomHelpers, source.context_class
+
+      context = source.context_class.new('deas-source', {})
+      assert_responds_to :a_custom_method, context
+    end
+
     should "optionally take and apply default locals to its context class" do
       local_name, local_val = [Factory.string, Factory.string]
       source = @source_class.new(@root, {
@@ -251,6 +260,10 @@ class Deas::Erubis::Source
         end
       end
     end
+  end
+
+  module SomeCustomHelpers
+    def a_custom_method; end
   end
 
 end

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -49,6 +49,11 @@ class Deas::Erubis::TemplateEngine
       assert_equal deas_source, source_opts[:deas_source]
     end
 
+    should "pass any given helpers option to its source" do
+      engine = Deas::Erubis::TemplateEngine.new('helpers' => [SomeCustomHelpers])
+      assert_includes SomeCustomHelpers, engine.erb_source.context_class
+    end
+
     should "use 'view' as the handler local name by default" do
       assert_equal 'view', subject.erb_handler_local
     end
@@ -69,6 +74,10 @@ class Deas::Erubis::TemplateEngine
       assert_equal logger_local, engine.erb_logger_local
     end
 
+  end
+
+  module SomeCustomHelpers
+    def a_custom_method; end
   end
 
 end


### PR DESCRIPTION
This adds an option to add in custom template helpers to the context
class used to render templates.  Use this to bring in 3rd-party
template helpers and render using them.

@jcredding ready for review.