### PR TITLE
pass in template helpers as a list OR just a single module

### DIFF
--- a/lib/deas-erubis/source.rb
+++ b/lib/deas-erubis/source.rb
@@ -60,7 +60,7 @@ module Deas::Erubis
     def build_context_class(opts)
       Class.new do
         include ::Deas::Erubis::TemplateHelpers
-        (opts[:helpers] || []).each{ |helper| include helper }
+        [*(opts[:helpers] || [])].each{ |helper| include helper }
         (opts[:locals]  || {}).each{ |k, v| define_method(k){ v } }
 
         def initialize(deas_source, locals)

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -86,8 +86,10 @@ class Deas::Erubis::Source
     end
 
     should "mixin custom template helpers to its context class" do
-      source = @source_class.new(@root, :helpers => [SomeCustomHelpers])
+      source = @source_class.new(@root, :helpers => SomeCustomHelpers)
+      assert_includes SomeCustomHelpers, source.context_class
 
+      source = @source_class.new(@root, :helpers => [SomeCustomHelpers])
       assert_includes SomeCustomHelpers, source.context_class
 
       context = source.context_class.new('deas-source', {})


### PR DESCRIPTION
The word "helpers" could be interpreted as "many methods on a single
module" so I think it is good to support sending just one module.
Plus this is safer and won't throw some random "undefined method"
error if they "do it wrong".

@jcredding ready for review.  Been sitting on this for a couple days and just keep forgetting to put it up.  Ran across this while thinking about the README's notes section.