### PR TITLE
switch to new `default_template_source` engine opt from Deas

### DIFF
--- a/deas-erubis.gemspec
+++ b/deas-erubis.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("assert", ["~> 2.12"])
 
-  gem.add_dependency("deas", ["~> 0.29"])
+  gem.add_dependency("deas", ["~> 0.30"])
   gem.add_dependency("erubis")
 
 end

--- a/lib/deas-erubis.rb
+++ b/lib/deas-erubis.rb
@@ -13,11 +13,11 @@ module Deas::Erubis
 
     def erb_source
       @erb_source ||= Source.new(self.source_path, {
-        :eruby       => self.opts['eruby'],
-        :cache       => self.opts['cache'],
-        :deas_source => self.opts['deas_template_source'],
-        :helpers     => self.opts['helpers'],
-        :locals      => { self.erb_logger_local => self.logger }
+        :eruby          => self.opts['eruby'],
+        :cache          => self.opts['cache'],
+        :default_source => self.opts['default_template_source'],
+        :helpers        => self.opts['helpers'],
+        :locals         => { self.erb_logger_local => self.logger }
       })
     end
 

--- a/lib/deas-erubis/source.rb
+++ b/lib/deas-erubis/source.rb
@@ -19,15 +19,15 @@ module Deas::Erubis
       @cache         = opts[:cache] ? Hash.new : NullCache.new
       @context_class = build_context_class(opts)
 
-      @deas_source = opts[:deas_source]
+      @default_source = opts[:default_source]
     end
 
     def render(file_name, locals, &content)
-      load(file_name).evaluate(@context_class.new(@deas_source, locals), &content)
+      load(file_name).evaluate(@context_class.new(@default_source, locals), &content)
     end
 
     def compile(filename, content)
-      eruby(filename, content).evaluate(@context_class.new(@deas_source, {}))
+      eruby(filename, content).evaluate(@context_class.new(@default_source, {}))
     end
 
     def eruby(filename, content)
@@ -63,8 +63,8 @@ module Deas::Erubis
         [*(opts[:helpers] || [])].each{ |helper| include helper }
         (opts[:locals]  || {}).each{ |k, v| define_method(k){ v } }
 
-        def initialize(deas_source, locals)
-          @deas_source = deas_source
+        def initialize(default_source, locals)
+          @default_source = default_source
 
           metaclass = class << self; self; end
           metaclass.class_eval do

--- a/lib/deas-erubis/template_helpers.rb
+++ b/lib/deas-erubis/template_helpers.rb
@@ -12,11 +12,11 @@ module Deas::Erubis
     module Methods
 
       def partial(name, locals = nil)
-        source_partial(@deas_source, name, locals)
+        source_partial(@default_source, name, locals)
       end
 
       def capture_partial(name, locals = nil, &c)
-        source_capture_partial(@deas_source, name, locals, &c)
+        source_capture_partial(@default_source, name, locals, &c)
       end
 
       def source_partial(source, name, locals = nil)

--- a/test/support/templates/with_capture_partial.erb
+++ b/test/support/templates/with_capture_partial.erb
@@ -4,5 +4,5 @@
   <% end %>
   <% capture_partial '_partial', 'local1' => local1 %>
   <% capture_partial '_partial_no_locals' %>
-  <% source_capture_partial @deas_source, '_partial_no_locals' %>
+  <% source_capture_partial @default_source, '_partial_no_locals' %>
 </div>

--- a/test/support/templates/with_partial.erb
+++ b/test/support/templates/with_partial.erb
@@ -1,5 +1,5 @@
 <div>
   <%= partial '_partial', 'local1' => local1 %>
   <%= partial '_partial_no_locals' %>
-  <%= source_partial @deas_source, '_partial_no_locals' %>
+  <%= source_partial @default_source, '_partial_no_locals' %>
 </div>

--- a/test/system/template_engine_tests.rb
+++ b/test/system/template_engine_tests.rb
@@ -53,10 +53,10 @@ class Deas::Erubis::TemplateEngine
   class TemplateHelperTests < SystemTests
     desc "template helpers"
     setup do
-      @deas_source = Deas::TemplateSource.new(TEMPLATE_ROOT).tap do |s|
+      @source = Deas::TemplateSource.new(TEMPLATE_ROOT).tap do |s|
         s.engine 'erb', Deas::Erubis::TemplateEngine
       end
-      @engine = @deas_source.engines['erb']
+      @engine = @source.engines['erb']
     end
 
     should "render partials" do

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -115,11 +115,11 @@ class Deas::Erubis::Source
       assert_equal local_val, context.send(local_name)
     end
 
-    should "set any deas source given to its context class as an ivar on init" do
-      deas_source = 'a-deas-source'
-      context = subject.context_class.new(deas_source, {})
+    should "set any default source given to its context class as an ivar on init" do
+      default_source = 'a-default-source'
+      context = subject.context_class.new(default_source, {})
 
-      assert_equal deas_source, context.instance_variable_get('@deas_source')
+      assert_equal default_source, context.instance_variable_get('@default_source')
     end
 
   end
@@ -139,16 +139,16 @@ class Deas::Erubis::Source
       assert_equal exp, subject.render(@file_name, @file_locals)
     end
 
-    should "pass its deas source to its context class" do
-      deas_source = 'a-deas-source'
-      source = @source_class.new(@root, :deas_source => deas_source)
+    should "pass its default source to its context class" do
+      default_source = 'a-deas-source'
+      source = @source_class.new(@root, :default_source => default_source)
       context_class = nil
       Assert.stub(source.context_class, :new) do |s, l|
         context_class = ContextClassSpy.new(s, l)
       end
       source.render(@file_name, @file_locals)
 
-      assert_equal deas_source, context_class.deas_source
+      assert_equal default_source, context_class.default_source
     end
 
   end
@@ -252,9 +252,9 @@ class Deas::Erubis::Source
   end
 
   class ContextClassSpy
-    attr_reader :deas_source
-    def initialize(deas_source, locals)
-      @deas_source = deas_source
+    attr_reader :default_source
+    def initialize(default_source, locals)
+      @default_source = default_source
       metaclass = class << self; self; end
       metaclass.class_eval do
         locals.each do |key, value|

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -40,13 +40,13 @@ class Deas::Erubis::TemplateEngine
     end
 
     should "pass any given deas template source to its source" do
-      deas_source = 'a-deas-source'
+      default_source = 'a-default-source'
       source_opts = nil
 
       Assert.stub(Deas::Erubis::Source, :new){ |root, opts| source_opts = opts }
-      Deas::Erubis::TemplateEngine.new('deas_template_source' => deas_source).erb_source
+      Deas::Erubis::TemplateEngine.new('default_template_source' => default_source).erb_source
 
-      assert_equal deas_source, source_opts[:deas_source]
+      assert_equal default_source, source_opts[:default_source]
     end
 
     should "pass any given helpers option to its source" do


### PR DESCRIPTION
This switches to requiring the latest Deas and using its newly
renamed `default_template_source` engine option.  This rename has
no behavior changes, just better communicates the intent of the
option.  The intent can be seen in how the non-source-specific template
helpers use the default source.

@jcredding this corresponds with redding/deas#166.  Ready for review.