### PR TITLE
switch to custom template evaluation based on erubis data

### DIFF
--- a/lib/deas-erubis/source.rb
+++ b/lib/deas-erubis/source.rb
@@ -27,14 +27,14 @@ module Deas::Erubis
     end
 
     def compile(filename, content)
-      eruby(filename, content).evaluate(@context_class.new(@default_source, {}))
+      template(filename, content).evaluate(@context_class.new(@default_source, {}))
     end
 
-    def eruby(filename, content)
-      @eruby_class.new(content, {
+    def template(filename, content)
+      Template.new(@eruby_class.new(content, {
         :bufvar   => BUFVAR_NAME,
         :filename => filename
-      })
+      }))
     end
 
     def inspect
@@ -49,7 +49,7 @@ module Deas::Erubis
       @cache[file_name] ||= begin
         filename = source_file_path(file_name).to_s
         content = File.send(File.respond_to?(:binread) ? :binread : :read, filename)
-        eruby(filename, content)
+        template(filename, content)
       end
     end
 
@@ -73,6 +73,21 @@ module Deas::Erubis
             end
           end
         end
+      end
+    end
+
+    class Template
+      attr_reader :src, :filename, :eruby_class, :eruby_bufvar
+
+      def initialize(erubis_eruby)
+        @src          = erubis_eruby.src
+        @filename     = erubis_eruby.filename
+        @eruby_class  = erubis_eruby.class
+        @eruby_bufvar = erubis_eruby.instance_variable_get('@bufvar')
+      end
+
+      def evaluate(context)
+        context.instance_eval(@src, @filename)
       end
     end
 

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -35,7 +35,7 @@ class Deas::Erubis::Source
     subject{ @source }
 
     should have_readers :root, :eruby_class, :cache, :context_class
-    should have_imeths :render, :compile, :eruby
+    should have_imeths :render, :compile, :template
 
     should "know its root" do
       assert_equal @root, subject.root.to_s
@@ -51,15 +51,13 @@ class Deas::Erubis::Source
       assert_equal eruby, source.eruby_class
     end
 
-    should "build eruby instances for a given template file" do
-      assert_kind_of subject.eruby_class, subject.eruby('basic', Factory.string)
-    end
+    should "build template objects for template files" do
+      filename = 'basic'
+      template = subject.template(filename, Factory.string)
 
-    should "build its eruby instances with the correct bufvar name" do
-      eruby = subject.eruby('basic', Factory.string)
-
-      exp = Deas::Erubis::Source::BUFVAR_NAME
-      assert_equal exp, eruby.instance_variable_get('@bufvar')
+      assert_equal filename,                          template.filename
+      assert_equal subject.eruby_class,               template.eruby_class
+      assert_equal Deas::Erubis::Source::BUFVAR_NAME, template.eruby_bufvar
     end
 
     should "not cache templates by default" do
@@ -159,12 +157,12 @@ class Deas::Erubis::Source
       @source = @source_class.new(@root, :cache => true)
     end
 
-    should "cache template eruby instances by their file name" do
+    should "cache templates by their file name" do
       exp = Factory.basic_erb_rendered(@file_locals)
       assert_equal exp, @source.render(@file_name, @file_locals)
 
       assert_equal [@file_name], @source.cache.keys
-      assert_kind_of @source.eruby_class, @source.cache[@file_name]
+      assert_kind_of Template, @source.cache[@file_name]
     end
 
   end
@@ -175,7 +173,7 @@ class Deas::Erubis::Source
       @source = @source_class.new(@root, :cache => false)
     end
 
-    should "not cache template eruby instances" do
+    should "not cache templates" do
       exp = Factory.basic_erb_rendered(@file_locals)
       assert_equal exp, @source.render(@file_name, @file_locals)
 


### PR DESCRIPTION
This change came about b/c our caching scheme was not working when
caching erubis eruby objects directly.  It seems evaluating against
an erubis eruby object changed its state.  So when caching those
objects, subsequent evaluation would be against altered state.

To work around this, we switch to using the erubis eruby objects
to just compile the template source.  We then store off that source
and some additional meta (mostly for testing purposes) and implement
our own evaluation by just instance eval'ing the source against
our context objects (which is all erubis' evaluate does anyway).

This allows for a similar api and the benefits of compiling templates
with erubis, while enabling our template caching design.

@jcredding this is my solution to the caching bug we saw when using this in our apps.  I never really found out why it wasn't working - just that state wasn't fresh on subsequent evals.  So I just decided to work around it.  Anyway, ready for review.