### PR TITLE
update source file globbing to support multi-engine extensions

### DIFF
--- a/lib/deas-erubis.rb
+++ b/lib/deas-erubis.rb
@@ -39,6 +39,8 @@ module Deas::Erubis
       self.erb_source.render(template_name, locals, &content)
     end
 
+    # this is used when chaining engines where another engine initially loads the
+    # template file
     def compile(template_name, compiled_content)
       self.erb_source.compile(template_name, compiled_content)
     end

--- a/lib/deas-erubis/source.rb
+++ b/lib/deas-erubis/source.rb
@@ -7,7 +7,6 @@ module Deas::Erubis
 
   class Source
 
-    EXT           = '.erb'.freeze
     BUFVAR_NAME   = '@_erb_buf'.freeze
     DEFAULT_ERUBY = ::Erubis::Eruby
 
@@ -54,7 +53,7 @@ module Deas::Erubis
     end
 
     def source_file_path(template_name)
-      Dir.glob(self.root.join("#{template_name}*#{EXT}")).first
+      Dir.glob(self.root.join("#{template_name}*")).first
     end
 
     def build_context_class(opts)

--- a/test/support/templates/basic_alt.erubis
+++ b/test/support/templates/basic_alt.erubis
@@ -1,0 +1,2 @@
+<h1>name: <%= name %></h1>
+<h2>local1: <%= local1 %></h2>

--- a/test/system/template_engine_tests.rb
+++ b/test/system/template_engine_tests.rb
@@ -10,9 +10,9 @@ class Deas::Erubis::TemplateEngine
     setup do
       @view = OpenStruct.new({
         :identifier => Factory.integer,
-        :name => Factory.string
+        :name       => Factory.string
       })
-      @locals = { 'local1' => Factory.string }
+      @locals  = { 'local1' => Factory.string }
       @content = Proc.new{ "<span>some content</span>" }
 
       @engine = Deas::Erubis::TemplateEngine.new('source_path' => TEMPLATE_ROOT)
@@ -41,8 +41,8 @@ class Deas::Erubis::TemplateEngine
 
     should "compile raw template markup" do
       template_name = 'compile'
-      file_path = TEMPLATE_ROOT.join("#{template_name}#{Deas::Erubis::Source::EXT}").to_s
-      file_content = File.read(file_path)
+      file_path     = TEMPLATE_ROOT.join("#{template_name}.erb").to_s
+      file_content  = File.read(file_path)
 
       exp = Factory.compile_erb_rendered(subject)
       assert_equal exp, subject.compile(template_name, file_content)

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -12,10 +12,6 @@ class Deas::Erubis::Source
     end
     subject{ @source_class }
 
-    should "know its extension" do
-      assert_equal '.erb',   subject::EXT
-    end
-
     should "know the bufvar name to use" do
       assert_equal '@_erb_buf', subject::BUFVAR_NAME
     end
@@ -49,15 +45,6 @@ class Deas::Erubis::Source
       eruby = 'some-eruby-class'
       source = @source_class.new(@root, :eruby => eruby)
       assert_equal eruby, source.eruby_class
-    end
-
-    should "build template objects for template files" do
-      filename = 'basic'
-      template = subject.template(filename, Factory.string)
-
-      assert_equal filename,                          template.filename
-      assert_equal subject.eruby_class,               template.eruby_class
-      assert_equal Deas::Erubis::Source::BUFVAR_NAME, template.eruby_bufvar
     end
 
     should "not cache templates by default" do
@@ -120,12 +107,21 @@ class Deas::Erubis::Source
       assert_equal default_source, context.instance_variable_get('@default_source')
     end
 
+    should "build template objects for template files" do
+      filename = 'basic'
+      template = subject.template(filename, Factory.string)
+
+      assert_equal filename,                          template.filename
+      assert_equal subject.eruby_class,               template.eruby_class
+      assert_equal Deas::Erubis::Source::BUFVAR_NAME, template.eruby_bufvar
+    end
+
   end
 
   class RenderTests < InitTests
     desc "`render` method"
     setup do
-      @template_name   = ["basic", "basic.html"].choice
+      @template_name = ['basic', 'basic_alt'].choice
       @file_locals = {
         'name'   => Factory.string,
         'local1' => Factory.integer

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -16,7 +16,7 @@ class Deas::Erubis::TemplateEngine
     subject{ @engine }
 
     should have_imeths :erb_source, :erb_handler_local, :erb_logger_local
-    should have_imeths :render, :partial
+    should have_imeths :render, :partial, :compile
 
     should "be a Deas template engine" do
       assert_kind_of Deas::TemplateEngine, subject


### PR DESCRIPTION
Now that deas supports multi-engine extensions per template file,
deas-erubis can't know that every template file it is asked to render
will end in a `.erb` extension.

In addition, deas-erubis shouldn't be in the business of requiring
its source files to end in `.erb` anyway. If the developer has
configured deas-erubis on a custom extension, `.erubis` for example,
then deas-erubis shouldn't care.  If deas has asked deas-erubis to
render this named template, it should just do it.

See redding/deas#205 for reference.

/cc @jcredding 