### PR TITLE
source: require named templates end in any given extension

### DIFF
--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -38,7 +38,7 @@ class Deas::Erubis::Source
     end
 
     should "know its extension for looking up source files" do
-      assert_equal '', subject.ext
+      assert_nil subject.ext
 
       source = @source_class.new(@root, :ext => 'erb')
       assert_equal '.erb', source.ext
@@ -156,15 +156,26 @@ class Deas::Erubis::Source
       source = @source_class.new(@root, :ext => 'erb')
       file_path = Factory.template_file('basic.html.erb')
       exp = Factory.basic_erb_rendered(@file_locals)
-      assert_equal exp, source.render('basic', @file_locals)
+      ['basic', 'basic.html', 'basic.html.erb'].each do |name|
+        assert_equal exp, source.render(name, @file_locals)
+      end
 
       source = @source_class.new(@root, :ext => 'erubis')
       file_path = Factory.template_file('basic_alt.erubis')
       exp = Factory.basic_erb_rendered(@file_locals)
-      assert_equal exp, source.render('basic_alt', @file_locals)
+      ['basic', 'basic_alt', 'basic_alt.erubis'].each do |name|
+        assert_equal exp, source.render(name, @file_locals)
+      end
 
       source = @source_class.new(@root, :ext => 'erb')
-      assert_raises(ArgumentError){ source.render('basic_alt', @file_locals) }
+      ['basic_alt', 'basic_alt.erubis'].each do |name|
+        assert_raises(ArgumentError){ source.render(name, @file_locals) }
+      end
+
+      source = @source_class.new(@root, :ext => 'html')
+      ['basic', 'basic.html', 'basic.html.erb'].each do |name|
+        assert_raises(ArgumentError){ source.render(name, @file_locals) }
+      end
     end
 
   end


### PR DESCRIPTION
If an optional extension is specified, ensure that any template files
end in the given extension when rendering from the source file.  This
is more strict and better enforces the intent of specifying an extension.
This also allows you to specify fully qualified template names and
have them be recognized as it now only adds the ext to the glob if
needed.

Also, this updates the error message that is raised when a named
template source file can't be found.  The goal is to be very explicit
about what the source is looking for that it couldn't find and also
only adds extension info if an extension has been specified.

Note: Nm does something similar with its source file lookups - see redding/nm#17 for reference.

@jcredding ready for review.