### PR TITLE
Pass deas template engine ext to the source

### DIFF
--- a/deas-erubis.gemspec
+++ b/deas-erubis.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("assert", ["~> 2.15.1"])
 
-  gem.add_dependency("deas",        ["~> 0.39.2"])
+  gem.add_dependency("deas",        ["~> 0.40.0"])
   gem.add_dependency("erubis")
   gem.add_dependency("much-plugin", ["~> 0.1.0"])
 

--- a/lib/deas-erubis.rb
+++ b/lib/deas-erubis.rb
@@ -13,6 +13,7 @@ module Deas::Erubis
 
     def erb_source
       @erb_source ||= Source.new(self.source_path, {
+        :ext            => self.opts['ext'],
         :eruby          => self.opts['eruby'],
         :cache          => self.opts['cache'],
         :default_source => self.opts['default_template_source'],

--- a/test/support/templates/view.aaa
+++ b/test/support/templates/view.aaa
@@ -1,0 +1,6 @@
+<%
+# This files is just to provide a conflict when rendering. If deas-nm isn't
+# passing an extension down to nm then nm will try and render this file which
+# will error.
+raise "oops - trying to render wrong template"
+%>

--- a/test/system/template_engine_tests.rb
+++ b/test/system/template_engine_tests.rb
@@ -15,7 +15,10 @@ class Deas::Erubis::TemplateEngine
       @locals  = { 'local1' => Factory.string }
       @content = Proc.new{ "<span>some content</span>" }
 
-      @engine = Deas::Erubis::TemplateEngine.new('source_path' => TEMPLATE_ROOT)
+      @engine = Deas::Erubis::TemplateEngine.new({
+        'source_path' => TEMPLATE_ROOT,
+        'ext'         => 'erb'
+      })
     end
     subject{ @engine }
 

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -10,7 +10,8 @@ class Deas::Erubis::TemplateEngine
     desc "Deas::Erubis::TemplateEngine"
     setup do
       @engine = Deas::Erubis::TemplateEngine.new({
-        'source_path' => TEST_SUPPORT_PATH
+        'source_path' => TEST_SUPPORT_PATH,
+        'ext'         => 'erb'
       })
     end
     subject{ @engine }
@@ -37,6 +38,12 @@ class Deas::Erubis::TemplateEngine
     should "pass any given cache option to its source" do
       engine = Deas::Erubis::TemplateEngine.new('cache' => true)
       assert_kind_of Hash, engine.erb_source.cache
+    end
+
+    should "pass any given ext option to its source" do
+      ext = Factory.string
+      engine = Deas::Erubis::TemplateEngine.new('ext' => ext)
+      assert_equal ".#{ext}", engine.erb_source.ext
     end
 
     should "pass any given deas template source to its source" do


### PR DESCRIPTION
This updates the template engine to pass its ext to the source. The
template engine ext is set by deas when the engine is registered.
This makes it so the source will use templates with the extension that
was used when registering the engine with deas. This is the expected
behavior and avoids confusion with the source randomly using a template
that does not match the registered extension.

This is part of fixing an issue with deas not rendering the expected
source template. This is because the source now no longer forces
template extensions to be `erb` (see PR 27). By not expecting an extension,
the source can't pick the correct file if there are multiple files with
the same composed name except for their extensions. For example, a common
pattern is to name a handler file and the template the same only the
handler will have `.rb` for its extension and the template would use
`.erb`. In this scenario, it's possible for the source to try and use
the ruby file as its template.

See #27 for reference.

@jcredding ready for review.