### PR TITLE
get working in modern ruby versions

### DIFF
--- a/deas-erubis.gemspec
+++ b/deas-erubis.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.15.1"])
+  gem.add_development_dependency("assert", ["~> 2.16.1"])
 
-  gem.add_dependency("deas",        ["~> 0.40.0"])
+  gem.add_dependency("deas",        ["~> 0.41.0"])
   gem.add_dependency("erubis")
-  gem.add_dependency("much-plugin", ["~> 0.1.0"])
+  gem.add_dependency("much-plugin", ["~> 0.2.0"])
 
 end

--- a/lib/deas-erubis/source.rb
+++ b/lib/deas-erubis/source.rb
@@ -60,7 +60,11 @@ module Deas::Erubis
     end
 
     def source_file_path(name)
-      Dir.glob(self.root.join(name.end_with?(@ext) ? name : "#{name}*#{@ext}")).first
+      Dir.glob(self.root.join(source_file_glob_string(name))).first
+    end
+
+    def source_file_glob_string(name)
+      !@ext.nil? && name.end_with?(@ext) ? name : "#{name}*#{@ext}"
     end
 
     def build_context_class(opts)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -15,3 +15,12 @@ TEMPLATE_CACHE_ROOT = ROOT.join('tmp/templates')
 require 'pry'
 
 require 'test/support/factory'
+
+# 1.8.7 backfills
+
+# Array#sample
+if !(a = Array.new).respond_to?(:sample) && a.respond_to?(:choice)
+  class Array
+    alias_method :sample, :choice
+  end
+end

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -128,7 +128,7 @@ class Deas::Erubis::Source
   class RenderTests < InitTests
     desc "`render` method"
     setup do
-      @template_name = ['basic', 'basic_alt'].choice
+      @template_name = ['basic', 'basic_alt'].sample
       @file_locals = {
         'name'   => Factory.string,
         'local1' => Factory.integer


### PR DESCRIPTION
This updates the gem dependencies to bring in the latest versions
(which also now work in modern ruby versions) and updates the test
suite to get up to convention for working in modern ruby versions.
This includes backfilling Array#sample so it works in 1.8.7.

Note: I had to fix Source file globbing to work in newer ruby
versions.  When globbing for template source files, deas-erubis
checks if the given template name ends in the Source's configured
extension (which can be `nil` if no extension has been configured).
If the name ends with the extension, Source globs the given name
exactly; if not, it fuzzy-globs the name. In 1.8.7, you can call
`String#end_with?` with a `nil` value and it returns `false` as
expected.  In newer versions, calling that method with a `nil`
value raises a `TypeError: no implicit conversion of nil into
String` exception (ugh).  So, this switches to now babysit modern
Ruby, hold its hand and manually handle globbing where there is no
configured extension. This gets things passing in modern Ruby. A
similar fix was needed in Nm as well.

See https://github.com/redding/nm/commit/fc36ca9f98ff222be0552cde7fe9ccb3d13a23cd for reference.

@jcredding ready for review.